### PR TITLE
Update to more recent dependency versions

### DIFF
--- a/comonad-extras.cabal
+++ b/comonad-extras.cabal
@@ -34,11 +34,11 @@ library
   build-depends:
     array                >= 0.3   && < 0.6,
     base                 >= 4     && < 5,
-    containers           >= 0.4   && < 0.6,
-    comonad              >= 4     && < 5,
+    containers           >= 0.4   && < 0.7,
+    comonad              >= 4     && < 6,
     distributive         >= 0.3.2 && < 1,
     semigroupoids        >= 4     && < 6,
-    transformers         >= 0.2   && < 0.5
+    transformers         >= 0.2   && < 0.6
 
   exposed-modules:
     Control.Comonad.Store.Zipper

--- a/src/Control/Comonad/Store/Pointer.hs
+++ b/src/Control/Comonad/Store/Pointer.hs
@@ -44,7 +44,9 @@ module Control.Comonad.Store.Pointer
   , module Control.Comonad.Store.Class
   ) where
 
+#if !defined(__GLASGOW_HASKELL__) || __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Comonad
 import Control.Comonad.Hoist.Class
 import Control.Comonad.Trans.Class

--- a/src/Control/Comonad/Store/Zipper.hs
+++ b/src/Control/Comonad/Store/Zipper.hs
@@ -15,7 +15,9 @@
 module Control.Comonad.Store.Zipper
   ( Zipper, zipper, zipper1, unzipper, size) where
 
+#if !defined(__GLASGOW_HASKELL__) || __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Comonad (Comonad(..))
 import Data.Functor.Extend
 import Data.Foldable


### PR DESCRIPTION
In particular: relax version upper bounds and suppress a warning in GHC 7.10+