### PR TITLE
Get comonad-extras building on GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
  - GHCVER=7.6.3 CABALVER=1.16
  - GHCVER=7.8.4 CABALVER=1.18
  - GHCVER=7.10.1 CABALVER=1.22
- - GHCVER=head CABALVER=1.22
+ - GHCVER=8.6.5 CABALVER=2.4.1.0
+ - GHCVER=head CABALVER=2.4.1.0
 
 matrix:
   allow_failures:

--- a/comonad-extras.cabal
+++ b/comonad-extras.cabal
@@ -1,6 +1,6 @@
 name:          comonad-extras
 category:      Control, Comonads
-version:       4.0
+version:       5.0
 license:       BSD3
 cabal-version: >= 1.6
 license-file:  LICENSE
@@ -34,11 +34,11 @@ library
   build-depends:
     array                >= 0.3   && < 0.6,
     base                 >= 4     && < 5,
-    containers           >= 0.4   && < 0.6,
-    comonad              >= 4     && < 5,
+    containers           >= 0.6   && < 0.7,
+    comonad              >= 5     && < 6,
     distributive         >= 0.3.2 && < 1,
-    semigroupoids        >= 4     && < 6,
-    transformers         >= 0.2   && < 0.5
+    semigroupoids        >= 5     && < 6,
+    transformers         >= 0.5   && < 0.6
 
   exposed-modules:
     Control.Comonad.Store.Zipper

--- a/src/Control/Comonad/Store/Pointer.hs
+++ b/src/Control/Comonad/Store/Pointer.hs
@@ -44,7 +44,6 @@ module Control.Comonad.Store.Pointer
   , module Control.Comonad.Store.Class
   ) where
 
-import Control.Applicative
 import Control.Comonad
 import Control.Comonad.Hoist.Class
 import Control.Comonad.Trans.Class
@@ -60,7 +59,7 @@ import Data.Typeable
 #endif
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 708
-instance (Typeable i, Typeable1 w) => Typeable1 (PointerT i w) where
+instance (Typeable i, Typeable w) => Typeable (PointerT i w) where
   typeOf1 diwa = mkTyConApp storeTTyCon [typeOf (i diwa), typeOf1 (w diwa)]
     where
       i :: PointerT i w a -> i

--- a/src/Control/Comonad/Store/Zipper.hs
+++ b/src/Control/Comonad/Store/Zipper.hs
@@ -15,7 +15,6 @@
 module Control.Comonad.Store.Zipper
   ( Zipper, zipper, zipper1, unzipper, size) where
 
-import Control.Applicative
 import Control.Comonad (Comonad(..))
 import Data.Functor.Extend
 import Data.Foldable


### PR DESCRIPTION
- bump to version 5 to correspond to comonad-5
- bump min+max versions of all dependencies to the latest in Hackage
- Get rid of now-unnecessary import of Control.Applicative
- Get rid of Typeable1 now that Typeable is poly-kinded
- Add GHC 8.6 to the travis CI matrix